### PR TITLE
Checkout scheduling bugs

### DIFF
--- a/src/inventory/views.py
+++ b/src/inventory/views.py
@@ -86,7 +86,7 @@ def compute_due_date(timeframe, checkout_date):
 
         # always due on a tuesday
         # shift a day to combat reserved-on-tues/due-on-tues
-        due = res.shift(day=1).shift(weekday=1).replace(hour=19)
+        due = res.shift(days=+1).shift(weekday=1).replace(hour=19)
 
         return due.datetime
     return None


### PR DESCRIPTION
## Problem

Users could submit equipment checkout reservations that overlap existing reservations. This was for two reasons:
1. We modified checkout dates after we check for existing reservations
2. We only check for one of four possible conditions when selecting conflicting reservations

## Solution

1. Move the date change logic above selecting existing reservations
2. Add the additional conditions to the query

## Bonus bug fix

Apparently, the `arrow` implementation for calculating the due date of a `CHECKOUT_WEEK` reservation would throw an exception. It has been fixed.