### PR TITLE
Better help text for "due-tuesday" checkouts

### DIFF
--- a/src/inventory/models.py
+++ b/src/inventory/models.py
@@ -22,7 +22,7 @@ CHECKOUT_WEEK = 'CHECKOUT_WEEK'
 CHECKOUT_TIMEFRAMES = [
     (CHECKOUT_3HR, '3hr checkout'),
     (CHECKOUT_24HR, '24hr checkout'),
-    (CHECKOUT_WEEK, 'Thurs-Tues checkout')
+    (CHECKOUT_WEEK, 'Checkout due Tues')
 ]
 
 


### PR DESCRIPTION
## Problem

The help text on a `CHECKOUT_WEEK` equipment checkout type indicates that the equipment can only be checked out on a Thursday and returned on a Tuesday, when the only rule is that it must be returned on a Tuesday. The functionality is correctly implemented, but the text is confusing from an administrator perspective.

#78 

## Solution

Change the help text