### PR TITLE
add certbot container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ src/static/media/uploads/*
 
 # assets
 !src/static/**/lib
+
+# certificates
+data/certbot

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,9 @@ services:
     volumes:
       - ./src/static:/var/www/static
       - ./nginx/sites-enabled.prod.conf:/etc/nginx/conf.d/sites-enabled.conf
-      - /etc/letsencrypt/copy:/etc/letsencrypt/login.faypublic.tv
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+
   django:
     restart: always
     command: gunicorn -w 3 --bind 0.0.0.0:8080 faypublic.wsgi

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,3 +24,10 @@ services:
 
   redis:
     restart: always
+
+  certbot:
+    image: certbot/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-domains=(jantimpe.dev)
+domains=(login.faypublic.tv)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="timpe31@gmail.com" # Adding a valid address is strongly recommended
-staging=1 # Set to 1 if you're testing your setup to avoid hitting request limits
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then
   read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -25,7 +25,7 @@ fi
 echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:1024 -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
@@ -38,7 +38,7 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --force-recre
 echo
 
 echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml run --rm --entrypoint "\
   rm -Rf /etc/letsencrypt/live/$domains && \
   rm -Rf /etc/letsencrypt/archive/$domains && \
   rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
@@ -61,7 +61,7 @@ esac
 # Enable staging mode if needed
 if [ $staging != "0" ]; then staging_arg="--staging"; fi
 
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
     $email_arg \

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+domains=(jantimpe.dev)
+rsa_key_size=4096
+data_path="./data/certbot"
+email="timpe31@gmail.com" # Adding a valid address is strongly recommended
+staging=1 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/nginx/sites-enabled.conf
+++ b/nginx/sites-enabled.conf
@@ -13,6 +13,10 @@ server {
 
     client_max_body_size 5000M;
 
+    location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
     location / {
         proxy_pass http://django:8080;
         proxy_set_header Host $host;

--- a/nginx/sites-enabled.conf
+++ b/nginx/sites-enabled.conf
@@ -13,10 +13,6 @@ server {
 
     client_max_body_size 5000M;
 
-    location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
-        }
-
     location / {
         proxy_pass http://django:8080;
         proxy_set_header Host $host;

--- a/nginx/sites-enabled.prod.conf
+++ b/nginx/sites-enabled.prod.conf
@@ -7,6 +7,10 @@ server {
     server_name login.faypublic.tv; # update with production values
     charset utf-8;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     location / {
         rewrite ^ https://$host$request_uri? permanent;
     }

--- a/nginx/sites-enabled.prod.conf
+++ b/nginx/sites-enabled.prod.conf
@@ -1,18 +1,3 @@
-
-# Cache expiration
-
-map $sent_http_content_type $expires {
-    default off;
-    text/html epoch;
-    text/css max;
-    application/javascript max;
-    ~image/ max;
-}
-
-##
-
-
-
 # Default server on port 80 redirects to https
 
 server {
@@ -29,19 +14,14 @@ server {
 
 ##
 
-
-
 # Application served on port 443 (https)
 
 server {
 
     # default server settings
-
-    # listen 80;
-    # listen [::]:80;
     listen 443 ssl http2 default_server;
     listen [::]:443 ssl http2 default_server;
-    server_name login.faypublic.tv; 
+    server_name jantimpe.dev;
     charset utf-8;
 
     # allow large files to be uploaded
@@ -59,37 +39,23 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    ##
     # ssl settings
-    ssl on;
     add_header Strict-Transport-Security "max-age=31536000" always;
-    ssl_session_cache shared:SSL:20m;
-    ssl_session_timeout 10m;
-
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers "ECDH+AESGCM:ECDH+AES256:ECDH+AES128:!ADH:!AECDH:!MD5;";
 
     ssl_stapling on;
     ssl_stapling_verify on;
     resolver 8.8.8.8 8.8.4.4;
 
-    ## UPDATE THESE WITH PRODUCTION CERTS
-    ## need to have a subdomain pointed to the box
-    ssl_certificate /etc/letsencrypt/login.faypublic.tv/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/login.faypublic.tv/privkey.pem;
-    ssl_trusted_certificate /etc/letsencrypt/login.faypublic.tv/chain.pem;
+    ssl_certificate /etc/letsencrypt/live/jantimpe.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/jantimpe.dev/privkey.pem;
+
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
     access_log /dev/stdout;
     error_log /dev/stderr info;
 
-    # proxy_ssl_server_name on;
-
-    ##
     # Caching and compression
-
-    expires $expires;
-
     gzip_disable "msie6";
     gzip_vary on;
     gzip_proxied any;
@@ -98,7 +64,6 @@ server {
     gzip_min_length 256;
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
-    ##
 }
 
 ##

--- a/nginx/sites-enabled.prod.conf
+++ b/nginx/sites-enabled.prod.conf
@@ -4,7 +4,7 @@ server {
 
     listen 80;
     listen [::]:80;
-    server_name jantimpe.dev; # update with production values
+    server_name login.faypublic.tv; # update with production values
     charset utf-8;
 
     location /.well-known/acme-challenge/ {
@@ -25,7 +25,7 @@ server {
     # default server settings
     listen 443 ssl http2 default_server;
     listen [::]:443 ssl http2 default_server;
-    server_name jantimpe.dev;
+    server_name login.faypublic.tv;
     charset utf-8;
 
     # allow large files to be uploaded
@@ -50,8 +50,8 @@ server {
     ssl_stapling_verify on;
     resolver 8.8.8.8 8.8.4.4;
 
-    ssl_certificate /etc/letsencrypt/live/jantimpe.dev/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/jantimpe.dev/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/login.faypublic.tv/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/login.faypublic.tv/privkey.pem;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

--- a/nginx/sites-enabled.prod.conf
+++ b/nginx/sites-enabled.prod.conf
@@ -4,7 +4,7 @@ server {
 
     listen 80;
     listen [::]:80;
-    server_name login.faypublic.tv; # update with production values
+    server_name jantimpe.dev; # update with production values
     charset utf-8;
 
     location /.well-known/acme-challenge/ {


### PR DESCRIPTION
## Problem

SSL certificate installation and renewal was a manual process.

#79 

## Solution

Utilize the certbot Docker image, which does automatic renewals.

## Implementation

`bash ./init-letsencrypt.sh` will create dummy certificates, install real certificates, delete dummy certificates, then start the container network